### PR TITLE
Feature/17 edit records

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,33 +1,49 @@
 class RecordsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_record, only: %i[show edit update]
 
   def index
     @record_type = params[:record_type] || "eaten"
-    @records = Record.where(record_type: @record_type).order(event_date: :desc)
+    @records = current_user.records.where(record_type: @record_type).order(event_date: :desc)
   end
 
   def new
-    @record = Record.new(record_type: params[:record_type] || "eaten")
+    @record = current_user.records.build(record_type: params[:record_type] || "eaten")
     @record.build_tasting if @record.eaten?
   end
 
   def create
-    p "届いたパラメータ: #{params[:record][:record_type]}"
     @record = current_user.records.build(record_params)
 
     if @record.save
-      redirect_to record_path(@record), notice: "#{@record.record_type}記録が保存されました。"
+      redirect_to record_path(@record), notice: "#{@record.record_type_i18n}記録が保存されました。"
     else
-      flash.now[:alert] = "記録が保存されませんでした。"
+      flash.now[:alert] = "#{@record.record_type_i18n}記録が保存されませんでした。"
       render :new, status: :unprocessable_entity
     end
   end
 
-  def show
-    @record = Record.find(params[:id])
+  def show; end
+
+  def edit
+    # tastingが未入力だった際も、編集時に空のインスタンスを生成してフォームに表示
+    @record.build_tasting if @record.eaten? && @record.tasting.nil?
+  end
+
+  def update
+    if @record.update(record_params)
+      redirect_to record_path(@record), notice: "#{@record.record_type_i18n}記録が更新されました。"
+    else
+      flash.now[:alert] = "#{@record.record_type_i18n}記録が更新されませんでした。"
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private
+
+  def set_record
+    @record = current_user.records.find(params[:id])
+  end
 
   def record_params
     params.require(:record).permit(:record_type, :image, :event_date, :brand_name, :memo, :recipient_name, tasting_attributes: [ :id, :sweetness, :richness, :melting ])

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -13,16 +13,26 @@ class Record < ApplicationRecord
   # 新規作成時にevent_dateのデフォルト値を今日に設定
   after_initialize :set_default_event_date, if: :new_record?
 
-  # ブランド名としてbrand_nameを仮想属性とし、保存前にブランドを検索または作成して関連付ける
+  # ブランド名としてbrand_nameを仮想属性とし、保存前にブランド名を検索または作成して関連付ける
   attr_accessor :brand_name
-  before_validation :set_brand_by_name
+  before_validation :set_brand_name
 
   # tasting_attributes=メソッドが作成される
   accepts_nested_attributes_for :tasting, allow_destroy: true
 
+  # enumのrecord_typeを日本語化
+  def record_type_i18n
+    I18n.t("enums.record.record_type.#{record_type}")
+  end
+
+  # 編集画面で入力したブランド名を維持するため
+  def brand_name
+    @brand_name || brand&.name
+  end
+
   private
 
-  def set_brand_by_name
+  def set_brand_name
     if brand_name.present?
       self.brand = Brand.find_or_create_by(name: brand_name)
     end

--- a/app/views/records/_eaten_form.html.erb
+++ b/app/views/records/_eaten_form.html.erb
@@ -22,16 +22,18 @@
         <!-- 本物の入力欄（hidden） -->
         <%= f.file_field :image, 
             class: "hidden", 
+            accept: "image/png, image/jpeg, image/gif",
             data: { 
               preview_target: "input", 
               action: "change->preview#update" 
             } %>
       </div>
       
-      <!-- プレビューの表示 -->
+      <!-- プレビューの表示：編集ページでも現在の画像が表示されるようにsrcとclassを出し分ける -->
       <div class="mt-2">
-        <img data-preview-target="image" src="" 
-            class="hidden w-full max-w-md h-60 object-contain rounded border border-gray-300 bg-gray-100">
+        <img data-preview-target="image" 
+          src="<%= f.object.image.attached? ? url_for(switch_image_path(f.object.image, 300, 300)) : "" %>"  
+          class="<%= f.object.image.attached? ? "" : "hidden" %> w-full max-w-md h-60 object-contain rounded border border-gray-300 bg-gray-100">
       </div>
     </div>
 
@@ -76,7 +78,7 @@
       <%= f.text_area :memo, class: "border border-gray-300 bg-white rounded px-3 py-5 mb-6 w-full" %>
     </div>
 
-    <%= f.submit "保存", class: "bg-amber-900 text-white px-4 py-2 my-5 rounded-lg w-full text-md hover:bg-amber-800" %>
+    <%= f.submit class: "bg-amber-900 text-white px-4 py-2 my-5 rounded-lg w-full text-md hover:bg-amber-800" %>
   <% end %>
   </div>
 </div>

--- a/app/views/records/_gifted_form.html.erb
+++ b/app/views/records/_gifted_form.html.erb
@@ -22,16 +22,18 @@
         <!-- 本物の入力欄（hidden） -->
         <%= f.file_field :image, 
             class: "hidden", 
-            data: { 
+            accept: "image/png, image/jpeg, image/gif",
+            data: {
               preview_target: "input", 
               action: "change->preview#update" 
             } %>
       </div>
       
-      <!-- プレビューの表示 -->
+      <!-- プレビューの表示：編集ページでも現在の画像が表示されるようにsrcとclassを出し分ける -->
       <div class="mt-2">
-        <img data-preview-target="image" src="" 
-            class="hidden w-full max-w-md h-60 object-contain rounded border border-gray-300 bg-gray-100">
+        <img data-preview-target="image" 
+          src="<%= f.object.image.attached? ? url_for(switch_image_path(f.object.image, 300, 300)) : "" %>"  
+          class="<%= f.object.image.attached? ? "" : "hidden" %> w-full max-w-md h-60 object-contain rounded border border-gray-300 bg-gray-100">
       </div>
     </div>
 
@@ -56,7 +58,7 @@
       <%= f.text_area :memo, class: "border border-gray-300 bg-white rounded px-3 py-5 mb-6 w-full" %>
     </div>
 
-    <%= f.submit "保存", class: "bg-amber-900 text-white px-4 py-2 my-5 rounded-lg w-full text-md hover:bg-amber-800" %>
+    <%= f.submit class: "bg-amber-900 text-white px-4 py-2 my-5 rounded-lg w-full text-md hover:bg-amber-800" %>
   <% end %>
   </div>
 </div>

--- a/app/views/records/edit.html.erb
+++ b/app/views/records/edit.html.erb
@@ -1,0 +1,6 @@
+<div class="record-type-toggle rounded-xl flex m-8">
+  <%= link_to "実食記録", edit_record_path(record_type: 'eaten'), data: { turbo: false }, class: "px-4 py-2 border #{@record.record_type == 'eaten' ? 'rounded-l-lg bg-taupe-600 text-white' : 'rounded-l-lg bg-white-100 hover:bg-taupe-200'}" %>
+  <%= link_to "贈答記録", edit_record_path(record_type: 'gifted'), data: { turbo: false }, class: "px-4 py-2 border #{@record.record_type == 'gifted' ? 'rounded-r-lg bg-taupe-600 text-white' : 'rounded-r-lg bg-white-100 hover:bg-taupe-200'}" %>
+</div>
+
+<%= render "#{@record.record_type}_form", record: @record %>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -50,8 +50,9 @@
           </li>
         </ul>
 
+        <!-- 編集ボタン -->
         <div class="absolute top-6 right-6">
-          <%= link_to "#", class: "flex flex-col items-center justify-center w-14 h-14 rounded-md text-amber-700 hover:bg-orange-200 transition-all duration-300" do %>
+          <%= link_to edit_record_path(@record), class: "flex flex-col items-center justify-center w-14 h-14 rounded-md text-amber-700 hover:bg-orange-200 transition-all duration-300" do %>
             <span class="text-xs mb-1 font-bold">編集</span> 
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="size-9">
               <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,10 @@
+ja:
+  enums:
+    record:
+      record_type:
+        eaten: 実食
+        gifted: 贈答
+  helpers:
+    submit:     
+      create: 保存
+      update: 更新

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   devise_for :users
   # Defines the root path route ("/")
   root "records#index"
-  resources :records, only: %i[index new create show]
+  resources :records, only: %i[index new create show edit update]
 end


### PR DESCRIPTION
### 概要
編集機能を実装します。

### 主な実装内容
- ルーティング、showページからの動線を修正
- コントローラーにedit/updateアクション追加
  - 同じ記述をset_recordでまとめる
  - tastingフォーム未入力の場合にも編集フォームを表示できるようにする
 - モデル追記
   - ブランド名の入力値を表示、維持できるようにする
   - i18nでenumを日本語化
- newで作成したフォームで編集のプレビューを表示させる修正
### 動作確認
- 詳細の編集ボタンからリンクできる
- 登録済みの入力値と同じ内容が表示される
- 編集をすると内容がアップデートされ、「実食/贈答記録が更新されました」と表示される
- rails cで日本語化の確認
```
myapp(dev)> key = "eaten"
myapp(dev)> I18n.t("enums.record.record_type.#{key}")
=> "実食"
myapp(dev)> key = "gifted"
myapp(dev)> I18n.t("enums.record.record_type.#{key}")
=> "贈答"
```