### PR TITLE
fix: 記録登録/編集画面の画像プレビューのエラー修正

### DIFF
--- a/app/views/records/_eaten_form.html.erb
+++ b/app/views/records/_eaten_form.html.erb
@@ -1,84 +1,57 @@
 <div class="min-h-screen flex flex-col justify-center lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-md">
     <h2 class="mb-6 text-center text-3xl font-extrabold">食べた記録</h2>
-  <%= form_with model: @record do |f| %>
-    <!-- エラーメッセージ表示 -->
-    <%= render 'shared/error_messages', object: f.object %>
-    <!-- 隠しデータ -->
-    <%= f.hidden_field :record_type, value: :eaten %>
+    <%= form_with model: @record do |f| %>
+      <!-- エラーメッセージ表示 -->
+      <%= render 'shared/error_messages', object: f.object %>
+      <!-- 隠しデータ -->
+      <%= f.hidden_field :record_type, value: :eaten %>
 
-    <!-- 画像アップロード -->
-    <div data-controller="preview" class="mb-6">
-      <!-- ボタンエリア -->
-      <div class="flex items-center space-x-4 mb-4">
-        <label class="text-md text-gray-700">画像:</label>
+      <!-- 画像アップロード -->
+      <%= render 'image_preview', f: f %>
 
-        <!-- ファイル選択ボタン -->
-        <label for="<%= f.field_id(:image) %>" 
-              class="cursor-pointer bg-white border border-gray-300 px-4 py-2 rounded text-sm hover:bg-gray-200">
-          ファイルを選択
-        </label>
+      <div class="field">
+        <%= f.label :event_date, "実食日:", class: "text-md text-gray-800" %>
+        <%= f.date_field :event_date, class: "border border-gray-300 bg-white rounded px-3 py-2 mb-6 w-full text-gray-600" %>
+      </div>         
 
-        <!-- 本物の入力欄（hidden） -->
-        <%= f.file_field :image, 
-            class: "hidden", 
-            accept: "image/png, image/jpeg, image/gif",
-            data: { 
-              preview_target: "input", 
-              action: "change->preview#update" 
-            } %>
+      <div class="field">
+        <%= f.label :brand_name, "ブランド名:", class: "text-md text-gray-800" %>
+        <%= f.text_field :brand_name, class: "border border-gray-300 bg-white rounded px-3 py-2 mb-6 w-full" %>
       </div>
-      
-      <!-- プレビューの表示：編集ページでも現在の画像が表示されるようにsrcとclassを出し分ける -->
-      <div class="mt-2">
-        <img data-preview-target="image" 
-          src="<%= f.object.image.attached? ? url_for(switch_image_path(f.object.image, 300, 300)) : "" %>"  
-          class="<%= f.object.image.attached? ? "" : "hidden" %> w-full max-w-md h-60 object-contain rounded border border-gray-300 bg-gray-100">
+
+      <!-- テイスティング項目 tasting_fieldsファイルでCSS統一 -->
+      <div class="field">
+        <%= f.fields_for :tasting do |t| %>
+          <%# 甘さ %>
+          <%= render 'tasting_fields',
+            form: t,
+            field: :sweetness,
+            label: "甘さ:",
+            options: Tasting::SWEETNESS_OPTS.values %>
+          
+          <%# 濃厚さ %>
+          <%= render 'tasting_fields',
+            form: t,
+            field: :richness,
+            label: "濃厚さ:",
+            options: Tasting::RICHNESS_OPTS.values %>
+
+          <%# 口どけ %>
+          <%= render 'tasting_fields',
+            form: t,
+            field: :melting,
+            label: "口どけ:",
+            options: Tasting::MELTING_OPTS.values %>
+        <% end %>
       </div>
-    </div>
 
-    <div class="field">
-      <%= f.label :event_date, "実食日:", class: "text-md text-gray-800" %>
-      <%= f.date_field :event_date, class: "border border-gray-300 bg-white rounded px-3 py-2 mb-6 w-full text-gray-600" %>
-    </div>         
+      <div class="mt-9">
+        <%= f.label :memo, "メモ:", class: "text-md text-gray-800" %>
+        <%= f.text_area :memo, class: "border border-gray-300 bg-white rounded px-3 py-5 mb-6 w-full" %>
+      </div>
 
-    <div class="field">
-      <%= f.label :brand_name, "ブランド名:", class: "text-md text-gray-800" %>
-      <%= f.text_field :brand_name, class: "border border-gray-300 bg-white rounded px-3 py-2 mb-6 w-full" %>
-    </div>
-
-    <!-- テイスティング項目 tasting_fieldsファイルでCSS統一 -->
-    <div class="field">
-      <%= f.fields_for :tasting do |t| %>
-        <%# 甘さ %>
-        <%= render 'tasting_fields',
-          form: t,
-          field: :sweetness,
-          label: "甘さ:",
-          options: Tasting::SWEETNESS_OPTS.values %>
-        
-        <%# 濃厚さ %>
-        <%= render 'tasting_fields',
-          form: t,
-          field: :richness,
-          label: "濃厚さ:",
-          options: Tasting::RICHNESS_OPTS.values %>
-
-        <%# 口どけ %>
-        <%= render 'tasting_fields',
-          form: t,
-          field: :melting,
-          label: "口どけ:",
-          options: Tasting::MELTING_OPTS.values %>
-      <% end %>
-    </div>
-
-    <div class="mt-9">
-      <%= f.label :memo, "メモ:", class: "text-md text-gray-800" %>
-      <%= f.text_area :memo, class: "border border-gray-300 bg-white rounded px-3 py-5 mb-6 w-full" %>
-    </div>
-
-    <%= f.submit class: "bg-amber-900 text-white px-4 py-2 my-5 rounded-lg w-full text-md hover:bg-amber-800" %>
-  <% end %>
+      <%= f.submit class: "bg-amber-900 text-white px-4 py-2 my-5 rounded-lg w-full text-md hover:bg-amber-800" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/records/_gifted_form.html.erb
+++ b/app/views/records/_gifted_form.html.erb
@@ -1,64 +1,36 @@
 <div class="min-h-screen flex flex-col justify-center lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-md">
     <h2 class="mb-6 text-center text-3xl font-extrabold">贈り物記録</h2>
-  <%= form_with model: @record do |f| %>
-    <!-- エラーメッセージ表示 -->
-    <%= render 'shared/error_messages', object: f.object %>
-    <!-- 隠しデータ -->
-    <%= f.hidden_field :record_type, value: :gifted %>
+    <%= form_with model: @record do |f| %>
+      <!-- エラーメッセージ表示 -->
+      <%= render 'shared/error_messages', object: f.object %>
+      <!-- 隠しデータ -->
+      <%= f.hidden_field :record_type, value: :gifted %>
 
-    <!-- 画像アップロード -->
-    <div data-controller="preview" class="mb-6">
-      <!-- ボタンエリア -->
-      <div class="flex items-center space-x-4 mb-4">
-        <label class="text-md text-gray-700">画像:</label>
+      <!-- 画像アップロード -->
+      <%= render 'image_preview', f: f %>
 
-        <!-- ファイル選択ボタン -->
-        <label for="<%= f.field_id(:image) %>" 
-              class="cursor-pointer bg-white border border-gray-300 px-4 py-2 rounded text-sm hover:bg-gray-200">
-          ファイルを選択
-        </label>
+      <div class="field">
+        <%= f.label :event_date, "贈答日:", class: "text-md text-gray-800" %>
+        <%= f.date_field :event_date, class: "border border-gray-300 bg-white rounded px-3 py-2 mb-6 w-full text-gray-600" %>
+      </div>         
 
-        <!-- 本物の入力欄（hidden） -->
-        <%= f.file_field :image, 
-            class: "hidden", 
-            accept: "image/png, image/jpeg, image/gif",
-            data: {
-              preview_target: "input", 
-              action: "change->preview#update" 
-            } %>
+      <div class="field">
+        <%= f.label :recipient_name, "宛名", class: "text-md text-gray-800" %>
+        <%= f.text_field :recipient_name, class: "border border-gray-300 bg-white rounded px-3 py-2 mb-6 w-full" %>
       </div>
-      
-      <!-- プレビューの表示：編集ページでも現在の画像が表示されるようにsrcとclassを出し分ける -->
-      <div class="mt-2">
-        <img data-preview-target="image" 
-          src="<%= f.object.image.attached? ? url_for(switch_image_path(f.object.image, 300, 300)) : "" %>"  
-          class="<%= f.object.image.attached? ? "" : "hidden" %> w-full max-w-md h-60 object-contain rounded border border-gray-300 bg-gray-100">
+
+      <div class="field">
+        <%= f.label :brand_name, "ブランド名:", class: "text-md text-gray-800" %>
+        <%= f.text_field :brand_name, class: "border border-gray-300 bg-white rounded px-3 py-2 mb-6 w-full" %>
       </div>
-    </div>
 
-    <div class="field">
-      <%= f.label :event_date, "贈答日:", class: "text-md text-gray-800" %>
-      <%= f.date_field :event_date, class: "border border-gray-300 bg-white rounded px-3 py-2 mb-6 w-full text-gray-600" %>
-    </div>         
+      <div class="field">
+        <%= f.label :memo, "メモ:", class: "text-md text-gray-800" %>
+        <%= f.text_area :memo, class: "border border-gray-300 bg-white rounded px-3 py-5 mb-6 w-full" %>
+      </div>
 
-    <div class="field">
-      <%= f.label :recipient_name, "宛名", class: "text-md text-gray-800" %>
-      <%= f.text_field :recipient_name, class: "border border-gray-300 bg-white rounded px-3 py-2 mb-6 w-full" %>
-    </div>
-
-    <div class="field">
-      <%= f.label :brand_name, "ブランド名:", class: "text-md text-gray-800" %>
-      <%= f.text_field :brand_name, class: "border border-gray-300 bg-white rounded px-3 py-2 mb-6 w-full" %>
-    </div>
-
-    
-    <div class="field">
-      <%= f.label :memo, "メモ:", class: "text-md text-gray-800" %>
-      <%= f.text_area :memo, class: "border border-gray-300 bg-white rounded px-3 py-5 mb-6 w-full" %>
-    </div>
-
-    <%= f.submit class: "bg-amber-900 text-white px-4 py-2 my-5 rounded-lg w-full text-md hover:bg-amber-800" %>
-  <% end %>
+      <%= f.submit class: "bg-amber-900 text-white px-4 py-2 my-5 rounded-lg w-full text-md hover:bg-amber-800" %>
+    <% end %>
   </div>
 </div>

--- a/app/views/records/_image_preview.html.erb
+++ b/app/views/records/_image_preview.html.erb
@@ -1,0 +1,40 @@
+<div data-controller="preview" class="mb-6">
+  <!-- ボタンエリア -->
+  <div class="flex items-center space-x-4 mb-4">
+    <label class="text-md text-gray-700">画像:</label>
+
+    <!-- ファイル選択ボタン -->
+    <label for="<%= f.field_id(:image) %>" 
+          class="cursor-pointer bg-white border border-gray-300 px-4 py-2 rounded text-xs hover:bg-gray-200">
+      ファイル選択
+    </label>
+
+    <!-- 本物の入力欄（hidden） -->
+    <%= f.file_field :image, 
+        class: "hidden", 
+        accept: "image/*",
+        data: { 
+          preview_target: "input", action: "change->preview#update" 
+        } %>
+  </div>
+
+  <!-- 注意書き -->
+  <small class="block text-sm text-gray-500">
+    ※画像形式はJPEG, PNG, GIF (5MB以内)で選択してください。
+  </small>
+  
+  <!-- プレビューの表示：編集ページでも現在の画像が表示されるようにする -->
+  <div class="mt-2">
+    <% if f.object.image.attached? && f.object.image.persisted? %>
+      <!-- 編集画面で既存の画像がありDBに保存されていればその画像を表示 -->
+      <img data-preview-target="image"
+        <%= image_tag switch_image_path(@record.image, 300, 300),
+          class: "w-full max-w-md h-60 object-contain rounded border border-gray-300 bg-gray-100" %>
+    <% else %>
+      <!-- 画像未選択であれば、hiddenで画面上から隠しておく(新規記録登録、編集どちらも対応) -->
+      <img data-preview-target="image" 
+        <%= image_tag "",
+          class: "hidden w-full max-w-md h-60 object-contain rounded-lg border border-gray-300 shadow-inner bg-gray-50" %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
### エラー内容
記録登録/編集画面(編集画面はおそらく画像未登録のもの)で出ていた以下のエラーを対処します。
```
Cannot get a signed_id for a new record
```
### エラーの原因
プレビューでurl_forを使用したことで、画像未登録時にURL(signed_id)を作成しようとしたのではないか。

#### url_for使用の経緯
編集画面でプレビュー画像が読み込まれず、url_forを追記すると解決したため
```
url_for使用前：Rubyオブジェクトが表示されていた
<img data-preview-target="image" src="#<ActiveStorage::VariantWithRecord:0....;" class=" w-full ...">
```
### 対処方法
url_forを使わない記述に変更（src=としていた部分をimage_tagに変更）

参考：https://github.com/rails/rails/issues/50234

