### PR TITLE
add: 記録の削除機能を実装

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,6 +1,6 @@
 class RecordsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_record, only: %i[show edit update]
+  before_action :set_record, only: %i[show edit update destroy]
 
   def index
     @record_type = params[:record_type] || "eaten"
@@ -31,12 +31,25 @@ class RecordsController < ApplicationController
   end
 
   def update
+    # 画像が変更された場合、Cloudinaryの古い画像を削除してから更新
+    @record.image.purge if params[:record][:image].present?
+
     if @record.update(record_params)
       redirect_to record_path(@record), notice: "#{@record.record_type_i18n}記録が更新されました。"
     else
       flash.now[:alert] = "#{@record.record_type_i18n}記録が更新されませんでした。"
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    # 画像が添付されていればCloudinaryから削除してからレコードを削除
+    if @record.image.attached?
+      @record.image.purge
+    end
+
+    @record.destroy!
+    redirect_to records_path(record_type: @record.record_type), notice: "#{@record.record_type_i18n}記録を1件削除しました。", status: :see_other
   end
 
   private

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,7 +1,7 @@
 class Record < ApplicationRecord
   belongs_to :user
   belongs_to :brand, optional: true
-  has_one_attached :image, dependent: :destroy
+  has_one_attached :image, dependent: :purge
   has_one :tasting, dependent: :destroy
   enum :record_type, { eaten: 0, gifted: 1 }
   validates :record_type, presence: true

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,11 +1,11 @@
 <title>ログインユーザー専用のフッター</title>
 <footer class="fixed bottom-0 w-full bg-orange-50 shadow-sm border-t border-amber-100 px-4 py-3">
   <% if user_signed_in? %>
+    <!-- 詳細→一覧ボタン/一覧→記録ボタンでリンクした際、元居たrecord_tyepと同じタイプにリンクするようcurrent_typeを設定 -->
+    <% current_type = @record&.record_type || params[:record_type] || 'eaten' %>
     <nav class="flex items-center justify-between w-full">
 
       <!-- 左:一覧 -->
-      <!-- 一覧画面から詳細画面に飛び、フッターの「一覧ボタン」で一覧に戻った時に元居たrecord_typeの一覧を表示するためpathにcurrent_typeを設定 -->
-      <% current_type = @record&.record_type || params[:type] || 'eaten' %>
       <div class="flex-1 flex justify-start px-30">
         <% unless controller.action_name == "index" %>
           <%= link_to records_path(record_type: current_type), class: "flex flex-col items-center justify-center w-14 h-14 rounded-md text-amber-700 hover:bg-orange-200 transition-all duration-300" do %>
@@ -18,7 +18,7 @@
       <!-- 中:記録 -->
       <div class="flex-1 flex justify-center">
         <% unless controller.action_name == "new" %>
-          <%= link_to new_record_path(record_type: :eaten), class: "flex flex-col items-center justify-center w-14 h-14 rounded-md text-amber-700 hover:bg-orange-200 transition-all duration-300" do %>
+          <%= link_to new_record_path(record_type: current_type), class: "flex flex-col items-center justify-center w-14 h-14 rounded-md text-amber-700 hover:bg-orange-200 transition-all duration-300" do %>
             <span class="text-xs mb-1 font-bold">記録</span>
             <svg xmlns="http://w3.org" fill="none" viewBox="0 0 24 24" stroke-width="4" stroke="currentColor" class="size-9"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
           <% end %>
@@ -28,13 +28,12 @@
       <!-- 右:削除 -->
       <div class="flex-1 flex justify-end px-30">
         <% if controller.action_name == "show" %>
-          <%= button_to "#", method: :delete, class: "flex flex-col items-center justify-center w-14 h-14 rounded-md text-red-600 hover:bg-red-100 transition-all duration-300" do %>
+          <%= button_to record_path(@record), method: :delete, class: "flex flex-col items-center justify-center w-14 h-14 rounded-md text-red-600 hover:bg-red-100 transition-all duration-300" do %>
             <span class="text-xs mb-1 font-bold">削除</span>
             <svg xmlns="http://w3.org" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor" class="size-8"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" /></svg>
           <% end %>
         <% end %>
       </div>
-
     </nav>
   <% end %>
 </footer>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   devise_for :users
   # Defines the root path route ("/")
   root "records#index"
-  resources :records, only: %i[index new create show edit update]
+  resources :records, only: %i[index new create show edit update destroy]
 end


### PR DESCRIPTION
### 概要
記録の削除機能を実装します。

### 実装内容
- ルーティング設定
- コントローラーにdestroyアクション追加
- モデルのimageに対してdependent: :destroy → purgeに念のため変更
- 遷移先のrecord_typeを合わせるようにビューを修正

### 動作確認
- レコードを削除でき、画像があればCloudinaryからも削除される
```
削除した際のログ
ActiveStorage::Blob Destroy (0.5ms)  DELETE FROM "active_storage_blobs" WHERE "active_storage_blobs"."id" = $1  [["id", 1...]]
  TRANSACTION (0.6ms)  COMMIT
  Cloudinary Storage (1235.9ms) Deleted file from key: c....
=> nil
```

### 備考
【削除してもCloudinaryの画像が消えない問題】
destroy!の前に画像があればimage.purgeする。
updateの画像変更の際も同じだったためupdateの前にimage.purgeをする修正を行なった。